### PR TITLE
Adding sudo false to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: elixir
 elixir:
   - 1.0.5


### PR DESCRIPTION
Adding `sudo:false` to speed up testing using containers.
