### PR TITLE
fix warnings after Elixir version 1.3 and add `mix.lock` and `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,20 @@
+# The directory Mix will write compiled artifacts to.
+/_build
+
+# If you run "mix test --cover", coverage assets end up here.
+/cover
+
+# The directory Mix downloads your dependencies sources to.
+/deps
+
+# Where 3rd-party dependencies like ExDoc output generated docs.
+/doc
+
+# Ignore .fetch files in case you like to edit your project deps locally.
+/.fetch
+
+# If the VM crashes, it generates a dump, let's ignore it too.
+erl_crash.dump
+
+# Also ignore archive artifacts (built via "mix archive.build").
+*.ez

--- a/lib/power_assert.ex
+++ b/lib/power_assert.ex
@@ -1,21 +1,22 @@
 defmodule PowerAssert do
   defmacro __using__(opts) do
     use_ex_unit = Keyword.get(opts, :use_ex_unit, false)
-    if !use_ex_unit do
-      quote do
-        use ExUnit.Case, unquote(opts)
-        import ExUnit.Assertions, except: [assert: 1, assert: 2]
-        import PowerAssert.Assertion
-      end
-    else
-      quote do
-        require PowerAssert.Assertion
-        defmacro power_assert(ast, msg \\ nil) do
-          quote do
-            PowerAssert.Assertion.assert(unquote(ast), unquote(msg))
+    case use_ex_unit do
+      false ->
+        quote do
+          use ExUnit.Case, unquote(opts)
+          import ExUnit.Assertions, except: [assert: 1, assert: 2]
+          import PowerAssert.Assertion
+        end
+      true ->
+        quote do
+          require PowerAssert.Assertion
+          defmacro power_assert(ast, msg \\ nil) do
+            quote do
+              PowerAssert.Assertion.assert(unquote(ast), unquote(msg))
+            end
           end
         end
-      end
     end
   end
 end

--- a/lib/power_assert/assertion.ex
+++ b/lib/power_assert/assertion.ex
@@ -471,11 +471,11 @@ defmodule PowerAssert.Assertion do
     value_len = String.length(value)
     lines =
       if latest_pos != -1 && latest_pos - (pos + value_len) > 0 do
-        [last_line|tail_lines] = lines |> Enum.reverse
+        [last_line|tail_lines] = Enum.reverse(lines)
         {before_str, after_str} = String.split_at(last_line, pos)
         {_removed_str, after_str} = String.split_at(after_str, value_len)
         line = before_str <> value <> after_str
-        [line|tail_lines] |> Enum.reverse
+        Enum.reverse([line|tail_lines])
       else
         line = String.duplicate(" ", pos + 1)
         line = replace_with_bar(line, values)
@@ -498,29 +498,28 @@ defmodule PowerAssert.Assertion do
     |> Enum.join("\n")
   end
   defp extra_information(left, right) when is_map(left) and is_map(right) do
-    left = left |> Map.delete(:__struct__)
-    right = right |> Map.delete(:__struct__)
+    left = Map.delete(left, :__struct__)
+    right = Map.delete(right, :__struct__)
     in_left = Map.split(left, Map.keys(right)) |> elem(1)
     in_right = Map.split(right, Map.keys(left)) |> elem(1)
     str = "\n"
     str =
-      unless Map.size(in_left) == 0 do
+      if Map.size(in_left) != 0 do
         str <> "\nonly in lhs: " <> inspect(in_left)
       else
         str
       end
     str =
-      unless Map.size(in_right) == 0 do
+      if Map.size(in_right) != 0 do
         str <> "\nonly in rhs: " <> inspect(in_right)
       else
         str
       end
     diff = collect_map_diff(left, right)
     str =
-      unless Enum.empty?(diff) do
-        str <> "\ndifference:\n" <> Enum.join(diff, "\n")
-      else
-        str
+      case Enum.empty?(diff) do
+        true -> str
+        false -> str <> "\ndifference:\n" <> Enum.join(diff, "\n")
       end
     str
   end

--- a/lib/power_assert/ast.ex
+++ b/lib/power_assert/ast.ex
@@ -12,17 +12,23 @@ defmodule PowerAssert.Ast do
   end
 
   defp do_traverse({form, meta, args}, acc, pre, post) do
-    unless is_atom(form) do
-      {form, acc} = pre.(form, acc) 
-      {form, acc} = do_traverse(form, acc, pre, post) 
-    end  
+    {form, acc} =
+      unless is_atom(form) do
+        {form, acc} = pre.(form, acc)
+        do_traverse(form, acc, pre, post)
+      else
+        {form, acc}
+      end
 
-    unless is_atom(args) do
-      {args, acc} = Enum.map_reduce(args, acc, fn x, acc ->
-        {x, acc} = pre.(x, acc) 
-        do_traverse(x, acc, pre, post) 
-      end) 
-    end  
+    {args, acc} =
+      unless is_atom(args) do
+        Enum.map_reduce(args, acc, fn x, acc ->
+          {x, acc} = pre.(x, acc)
+          do_traverse(x, acc, pre, post)
+        end)
+      else
+        {args, acc}
+      end
 
     post.({form, meta, args}, acc)
   end  

--- a/lib/power_assert/ast.ex
+++ b/lib/power_assert/ast.ex
@@ -13,21 +13,23 @@ defmodule PowerAssert.Ast do
 
   defp do_traverse({form, meta, args}, acc, pre, post) do
     {form, acc} =
-      unless is_atom(form) do
-        {form, acc} = pre.(form, acc)
-        do_traverse(form, acc, pre, post)
-      else
-        {form, acc}
+      case is_atom(form) do
+        false ->
+          {form, acc} = pre.(form, acc)
+          do_traverse(form, acc, pre, post)
+        true ->
+          {form, acc}
       end
 
     {args, acc} =
-      unless is_atom(args) do
-        Enum.map_reduce(args, acc, fn x, acc ->
-          {x, acc} = pre.(x, acc)
-          do_traverse(x, acc, pre, post)
-        end)
-      else
-        {args, acc}
+      case is_atom(args) do
+        false ->
+          Enum.map_reduce(args, acc, fn x, acc ->
+            {x, acc} = pre.(x, acc)
+            do_traverse(x, acc, pre, post)
+          end)
+        true ->
+          {args, acc}
       end
 
     post.({form, meta, args}, acc)

--- a/mix.exs
+++ b/mix.exs
@@ -13,7 +13,7 @@ defmodule PowerAssert.Mixfile do
      ],
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
-     deps: deps]
+     deps: deps()]
   end
 
   # Configuration for the OTP application

--- a/mix.lock
+++ b/mix.lock
@@ -1,0 +1,4 @@
+%{"earmark": {:hex, :earmark, "1.2.0", "bf1ce17aea43ab62f6943b97bd6e3dc032ce45d4f787504e3adf738e54b42f3a", [:mix], []},
+  "ex_doc": {:hex, :ex_doc, "0.15.0", "e73333785eef3488cf9144a6e847d3d647e67d02bd6fdac500687854dd5c599f", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, optional: false]}]},
+  "ex_spec": {:hex, :ex_spec, "2.0.1", "8bdbd6fa85995fbf836ed799571d44be6f9ebbcace075209fd0ad06372c111cf", [:mix], []},
+  "shouldi": {:hex, :shouldi, "0.3.2", "971f614669b5f37c03507ba643bb8e59aa165ac50ca66d726c9db53be255e440", [:mix], []}}


### PR DESCRIPTION
Elixir 1.4.2 で、現在 issue に上がっている #8 を除いて `mix test` が通ることを確認しています。

- 警告が出ていたので直しました
- `git status` 等を実行した時に `_build/` や `deps/` が変更に出てきて邪魔だったので、`mix new` で自動生成したプロジェクトに入っている `.gitignore` をコピーしておきました。
- `mix.lock` ファイルが無かったので追加しておきました。`mix.lock` ファイルは、依存しているライブラリのバージョンを固定するために必要なので、付けておいた方が良いと思います。
- `test/` の警告は直していません