### PR TITLE
fix the warning:

### DIFF
--- a/test/shouldi/should_test.exs
+++ b/test/shouldi/should_test.exs
@@ -22,7 +22,7 @@ defmodule ShouldTest do
 
   having "use power assert inside having" do
     setup context do
-      Dict.put context, :arr, [1,2,3]
+      Map.put context, :arr, [1,2,3]
     end
     should "use power assert", context do
       try do


### PR DESCRIPTION
Dict.put/3 is deprecated, use the Map module for working with maps or
the Keyword module for working with keyword lists