### PR TITLE
Use Kernel.map_size/1 instead of deprecated Map.size/1

### DIFF
--- a/lib/power_assert/assertion.ex
+++ b/lib/power_assert/assertion.ex
@@ -515,13 +515,13 @@ defmodule PowerAssert.Assertion do
     in_right = Map.split(right, Map.keys(left)) |> elem(1)
     str = "\n"
     str =
-      if Map.size(in_left) != 0 do
+      if map_size(in_left) != 0 do
         str <> "\nonly in lhs: " <> inspect(in_left)
       else
         str
       end
     str =
-      if Map.size(in_right) != 0 do
+      if map_size(in_right) != 0 do
         str <> "\nonly in rhs: " <> inspect(in_right)
       else
         str


### PR DESCRIPTION
I compiled power_assert_ex on Elixir 1.9.4 and got the following warnings:
```
warning: Map.size/1 is deprecated. Use Kernel.map_size/1 instead
Found at 2 locations:
  lib/power_assert/assertion.ex:518
  lib/power_assert/assertion.ex:524
```

This commit fixed the warnings.