### PR TITLE
update versions to test with CI following the Elixir's documentation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,31 +1,39 @@
 sudo: false
 language: elixir
 elixir:
-  - 1.4.5
-  - 1.5.3
   - 1.6.6
   - 1.7.4
-  - 1.8.1
+  - 1.8.2
+  - 1.9.4
+  - 1.10.4
+  - 1.11.2
 otp_release:
-  - 18.3
   - 19.3
   - 20.3
   - 21.3
+  - 22.3
+  - 23.1
 matrix:
   exclude:
-    - elixir: 1.4.5
-      otp_release: 18.3
-    - elixir: 1.4.5
-      otp_release: 21.3
-    - elixir: 1.5.3
-      otp_release: 18.3
-    - elixir: 1.5.3
-      otp_release: 21.3
     - elixir: 1.6.6
-      otp_release: 18.3
+      otp_release: 22.3
+    - elixir: 1.6.6
+      otp_release: 23.1
     - elixir: 1.7.4
-      otp_release: 18.3
-    - elixir: 1.8.1
-      otp_release: 18.3
-    - elixir: 1.8.1
+      otp_release: 23.1
+    - elixir: 1.8.2
       otp_release: 19.3
+    - elixir: 1.8.2
+      otp_release: 23.1
+    - elixir: 1.9.4
+      otp_release: 19.3
+    - elixir: 1.9.4
+      otp_release: 23.1
+    - elixir: 1.10.4
+      otp_release: 19.3
+    - elixir: 1.10.4
+      otp_release: 20.3
+    - elixir: 1.11.2
+      otp_release: 19.3
+    - elixir: 1.11.2
+      otp_release: 20.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 language: elixir
 elixir:
   - 1.6.6
@@ -12,23 +11,23 @@ otp_release:
   - 20.3
   - 21.3
   - 22.3
-  - 23.1
+  - 23.0
 matrix:
   exclude:
     - elixir: 1.6.6
       otp_release: 22.3
     - elixir: 1.6.6
-      otp_release: 23.1
+      otp_release: 23.0
     - elixir: 1.7.4
-      otp_release: 23.1
+      otp_release: 23.0
     - elixir: 1.8.2
       otp_release: 19.3
     - elixir: 1.8.2
-      otp_release: 23.1
+      otp_release: 23.0
     - elixir: 1.9.4
       otp_release: 19.3
     - elixir: 1.9.4
-      otp_release: 23.1
+      otp_release: 23.0
     - elixir: 1.10.4
       otp_release: 19.3
     - elixir: 1.10.4


### PR DESCRIPTION
security patch are provided in higher versions 1.6 and above

https://hexdocs.pm/elixir/1.11.2/compatibility-and-deprecations.html