### PR TITLE
remove warnings on 1.11

### DIFF
--- a/test/power_assert_test.exs
+++ b/test/power_assert_test.exs
@@ -299,7 +299,7 @@ defmodule PowerAssertAssertionTest do
   end
 
   test "map expr" do
-    expect = current_version_expectation("1.10.0", %{
+    expect = expectation_by_version("1.10.0", %{
       before: """
               map.value()
               |   |
@@ -1159,7 +1159,7 @@ defmodule PowerAssertAssertionTest do
     end
   end
 
-  def current_version_expectation(version, %{before: expect_before, after: expect_after}) do
+  def expectation_by_version(version, %{before: expect_before, after: expect_after}) do
     case Version.compare(System.version(), version) do
       :lt -> expect_before
       _ -> expect_after

--- a/test/power_assert_test.exs
+++ b/test/power_assert_test.exs
@@ -300,14 +300,14 @@ defmodule PowerAssertAssertionTest do
 
   test "map expr" do
     expect = """
-    map.value()
+    map.value
     |   |
     |   false
     %{value: false}
     """
     assert_helper(expect, fn () ->
       map = %{value: false}
-      Assertion.assert map.value()
+      Assertion.assert map.value
     end)
 
     expect = """
@@ -326,15 +326,15 @@ defmodule PowerAssertAssertionTest do
 
   test "nested map expr" do
     expect = """
-    map.value().value()
-    |   |       |
-    |   |       false
+    map.value.value
+    |   |     |
+    |   |     false
     |   %{value: false}
     %{value: %{value: false}}
     """
     assert_helper(expect, fn () ->
       map = %{value: %{value: false}}
-      Assertion.assert map.value().value()
+      Assertion.assert map.value.value
     end)
   end
 

--- a/test/power_assert_test.exs
+++ b/test/power_assert_test.exs
@@ -299,22 +299,20 @@ defmodule PowerAssertAssertionTest do
   end
 
   test "map expr" do
-    expect = case Version.compare(System.version(), "1.10.0") do
-      :lt ->
-        """
-        map.value()
-        |   |
-        |   false
-        %{value: false}
-        """
-      _ ->
-        """
-        map.value
-        |   |
-        |   false
-        %{value: false}
-        """
-    end
+    expect = current_version_expectation("1.10.0", %{
+      before: """
+              map.value()
+              |   |
+              |   false
+              %{value: false}
+              """,
+      after:  """
+              map.value
+              |   |
+              |   false
+              %{value: false}
+              """
+    })
     assert_helper(expect, fn () ->
       map = %{value: false}
       Assertion.assert map.value
@@ -1160,4 +1158,12 @@ defmodule PowerAssertAssertionTest do
         assert Regex.match?(expect, error.message)
     end
   end
+
+  def current_version_expectation(version, %{before: expect_before, after: expect_after}) do
+    case Version.compare(System.version(), version) do
+      :lt -> expect_before
+      _ -> expect_after
+    end
+  end
+
 end

--- a/test/power_assert_test.exs
+++ b/test/power_assert_test.exs
@@ -1141,16 +1141,6 @@ defmodule PowerAssertAssertionTest do
         assert expect == error.message
     end
   end
-  def assert_helper(expects, func) when is_list(expects) do
-    [expect1, expect2] = Enum.map expects, &(String.trim(&1))
-    try do
-      func.()
-      assert false, "should be failed test #{expects}"
-    rescue
-      error ->
-        assert (expect1 == error.message) || (expect2 == error.message)
-    end
-  end
   def assert_helper(expect, func) do
     try do
       func.()

--- a/test/power_assert_test.exs
+++ b/test/power_assert_test.exs
@@ -299,12 +299,22 @@ defmodule PowerAssertAssertionTest do
   end
 
   test "map expr" do
-    expect = """
-    map.value
-    |   |
-    |   false
-    %{value: false}
-    """
+    expect = case Version.compare(System.version(), "1.10.0") do
+      :lt ->
+        """
+        map.value()
+        |   |
+        |   false
+        %{value: false}
+        """
+      _ ->
+        """
+        map.value
+        |   |
+        |   false
+        %{value: false}
+        """
+    end
     assert_helper(expect, fn () ->
       map = %{value: false}
       Assertion.assert map.value
@@ -325,13 +335,24 @@ defmodule PowerAssertAssertionTest do
   end
 
   test "nested map expr" do
-    expect = """
-    map.value.value
-    |   |     |
-    |   |     false
-    |   %{value: false}
-    %{value: %{value: false}}
-    """
+    expect = case Version.compare(System.version(), "1.10.0") do
+      :lt ->
+        """
+        map.value().value()
+        |   |       |
+        |   |       false
+        |   %{value: false}
+        %{value: %{value: false}}
+        """
+      _ ->
+        """
+        map.value.value
+        |   |     |
+        |   |     false
+        |   %{value: false}
+        %{value: %{value: false}}
+        """
+    end
     assert_helper(expect, fn () ->
       map = %{value: %{value: false}}
       Assertion.assert map.value.value

--- a/test/power_assert_test.exs
+++ b/test/power_assert_test.exs
@@ -300,18 +300,18 @@ defmodule PowerAssertAssertionTest do
 
   test "map expr" do
     expect = expectation_by_version("1.10.0", %{
-      before: """
-              map.value()
-              |   |
-              |   false
-              %{value: false}
-              """,
-      after:  """
-              map.value
-              |   |
-              |   false
-              %{value: false}
-              """
+      earlier: """
+               map.value()
+               |   |
+               |   false
+               %{value: false}
+               """,
+      later:   """
+               map.value
+               |   |
+               |   false
+               %{value: false}
+               """
     })
     assert_helper(expect, fn () ->
       map = %{value: false}
@@ -1159,10 +1159,10 @@ defmodule PowerAssertAssertionTest do
     end
   end
 
-  def expectation_by_version(version, %{before: expect_before, after: expect_after}) do
+  def expectation_by_version(version, %{earlier: expect_earlier, later: expect_later}) do
     case Version.compare(System.version(), version) do
-      :lt -> expect_before
-      _ -> expect_after
+      :lt -> expect_earlier
+      _ -> expect_later
     end
   end
 


### PR DESCRIPTION
- remove warnings running `mix test` on Elixir 1.11
- refactor test code that have expectation changed by specific version

close #33 