### PR TITLE
hide `inject_store_code` explicitly

### DIFF
--- a/lib/power_assert/assertion.ex
+++ b/lib/power_assert/assertion.ex
@@ -26,7 +26,7 @@ defmodule PowerAssert.Assertion do
     [_ | t] = String.split(Macro.to_string(ast), " = ")
     rhs_expr = Enum.join(t, " = ")
     rhs_index = (Macro.to_string(left) |> String.length()) + @assign_len
-    injected_rhs_ast = inject_store_code(right, rhs_expr, rhs_index)
+    injected_rhs_ast = __inject_store_code__(right, rhs_expr, rhs_index)
     message_ast = message_ast(msg)
 
     left = Macro.expand(left, __CALLER__)
@@ -74,9 +74,9 @@ defmodule PowerAssert.Assertion do
     code = Macro.escape(ast)
     [lhs_expr | t] = String.split(Macro.to_string(ast), " == ")
     rhs_expr = Enum.join(t, " == ")
-    injected_lhs_ast = inject_store_code(left, lhs_expr)
+    injected_lhs_ast = __inject_store_code__(left, lhs_expr)
     rhs_index = (Macro.to_string(left) |> String.length()) + @equal_len
-    injected_rhs_ast = inject_store_code(right, rhs_expr, rhs_index)
+    injected_rhs_ast = __inject_store_code__(right, rhs_expr, rhs_index)
     message_ast = message_ast(msg)
 
     quote do
@@ -101,7 +101,7 @@ defmodule PowerAssert.Assertion do
 
   defmacro assert(ast, msg) do
     code = Macro.escape(ast)
-    injected_ast = inject_store_code(ast, Macro.to_string(ast))
+    injected_ast = __inject_store_code__(ast, Macro.to_string(ast))
 
     message_ast = message_ast(msg)
 
@@ -139,7 +139,7 @@ defmodule PowerAssert.Assertion do
   end
 
   @doc false
-  def inject_store_code(ast, expr, default_index \\ 0) do
+  def __inject_store_code__(ast, expr, default_index \\ 0) do
     positions = detect_position(ast, expr, default_index)
 
     {injected_ast, _} =

--- a/lib/power_assert/debug.ex
+++ b/lib/power_assert/debug.ex
@@ -1,6 +1,4 @@
 defmodule PowerAssert.Debug do
-  import PowerAssert.Assertion
-
   @moduledoc """
   This module provides debug utilities
   """
@@ -18,7 +16,7 @@ defmodule PowerAssert.Debug do
   """
   defmacro puts_expr(ast) do
     code = Macro.escape(ast)
-    injected_ast = inject_store_code(ast, Macro.to_string(ast))
+    injected_ast = PowerAssert.Assertion.__inject_store_code__(ast, Macro.to_string(ast))
 
     quote do
       unquote(injected_ast)


### PR DESCRIPTION
`inject_store_code` is internal use only so hide it from automatically importing not only documentation.

> Start the function name with one or two underscores, for example, __add__/2, and add @doc false. The compiler does not import functions with leading underscores and they hint to anyone reading the code of their intended private usage.

https://hexdocs.pm/elixir/writing-documentation.html#hiding-internal-modules-and-functions